### PR TITLE
PEP8 code style formatting

### DIFF
--- a/planet/control/in_graph_batch_env.py
+++ b/planet/control/in_graph_batch_env.py
@@ -117,9 +117,9 @@ class InGraphBatchEnv(object):
     reward = tf.zeros_like(indices, tf.float32)
     done = tf.zeros_like(indices, tf.int32)
     with tf.control_dependencies([
-        tf.scatter_update(self._observ, indices, observ),
-        tf.scatter_update(self._reward, indices, reward),
-        tf.scatter_update(self._done, indices, tf.to_int32(done))]):
+            tf.scatter_update(self._observ, indices, observ),
+            tf.scatter_update(self._reward, indices, reward),
+            tf.scatter_update(self._done, indices, tf.to_int32(done))]):
       return tf.identity(observ)
 
   @property

--- a/planet/control/planning.py
+++ b/planet/control/planning.py
@@ -24,9 +24,9 @@ from planet import tools
 
 
 def cross_entropy_method(
-    cell, objective_fn, state, obs_shape, action_shape, horizon,
-    amount=1000, topk=100, iterations=10, discount=0.99,
-    min_action=-1, max_action=1):
+        cell, objective_fn, state, obs_shape, action_shape, horizon,
+        amount=1000, topk=100, iterations=10, discount=0.99,
+        min_action=-1, max_action=1):
   obs_shape, action_shape = tuple(obs_shape), tuple(action_shape)
   original_batch = tools.shape(tools.nested.flatten(state)[0])[0]
   initial_state = tools.nested.map(lambda tensor: tf.tile(

--- a/planet/control/simulate.py
+++ b/planet/control/simulate.py
@@ -29,8 +29,8 @@ from planet.tools import streaming_mean
 
 
 def simulate(
-    step, env_ctor, duration, num_agents, agent_config,
-    env_processes=False, name='simulate'):
+        step, env_ctor, duration, num_agents, agent_config,
+        env_processes=False, name='simulate'):
   summaries = []
   with tf.variable_scope(name):
     return_, image, action, reward = collect_rollouts(
@@ -52,7 +52,7 @@ def simulate(
 
 
 def collect_rollouts(
-    step, env_ctor, duration, num_agents, agent_config, env_processes):
+        step, env_ctor, duration, num_agents, agent_config, env_processes):
   batch_env = define_batch_env(env_ctor, num_agents, env_processes)
   agent = mpc_agent.MPCAgent(batch_env, step, False, False, agent_config)
 

--- a/planet/models/rssm.py
+++ b/planet/models/rssm.py
@@ -45,8 +45,8 @@ class RSSM(base.Base):
   """
 
   def __init__(
-      self, state_size, belief_size, embed_size, mean_only=False,
-      min_stddev=1e-5):
+          self, state_size, belief_size, embed_size, mean_only=False,
+          min_stddev=1e-5):
     self._state_size = state_size
     self._belief_size = belief_size
     self._embed_size = embed_size

--- a/planet/networks/basic.py
+++ b/planet/networks/basic.py
@@ -24,7 +24,7 @@ from planet import tools
 
 
 def feed_forward(
-    state, data_shape, num_layers=2, activation=None, cut_gradient=False):
+        state, data_shape, num_layers=2, activation=None, cut_gradient=False):
   """Create a model returning unnormalized MSE distribution."""
   hidden = state
   if cut_gradient:

--- a/planet/scripts/configs.py
+++ b/planet/scripts/configs.py
@@ -97,6 +97,7 @@ def _tasks(config, params):
         'cartpole_balance', 'cartpole_swingup', 'finger_spin', 'cheetah_run',
         'cup_catch', 'walker_walk']
   tasks = [getattr(tasks_lib, name)(config, params) for name in tasks]
+
   def common_spaces_ctor(task, action_spaces):
     env = task.env_ctor()
     env = control.wrappers.SelectObservations(env, ['image'])

--- a/planet/scripts/tasks.py
+++ b/planet/scripts/tasks.py
@@ -98,6 +98,7 @@ def humanoid_walk(config, params):
 
 def _dm_control_env(action_repeat, max_length, domain, task):
   from dm_control import suite
+
   def env_ctor():
     env = control.wrappers.DeepMindWrapper(suite.load(domain, task), (64, 64))
     env = control.wrappers.ActionRepeat(env, action_repeat)

--- a/planet/scripts/train.py
+++ b/planet/scripts/train.py
@@ -88,7 +88,7 @@ def process(logdir, config, args):
       max_episodes=config.max_episodes,
       action_noise=config.fixed_action_noise)
   for score in training.utility.train(
-      training.define_model, dataset, logdir, config):
+          training.define_model, dataset, logdir, config):
     yield score
 
 

--- a/planet/tools/count_dataset.py
+++ b/planet/tools/count_dataset.py
@@ -28,6 +28,7 @@ def count_dataset(directory, key='reward'):
     message = "Data set directory '{}' does not exist."
     raise ValueError(message.format(directory))
   pattern = os.path.join(directory, '*.npz')
+
   def func():
     filenames = tf.gfile.Glob(pattern)
     episodes = len(filenames)

--- a/planet/tools/custom_optimizer.py
+++ b/planet/tools/custom_optimizer.py
@@ -25,8 +25,8 @@ from planet.tools import filter_variables
 class CustomOptimizer(object):
 
   def __init__(
-      self, optimizer_cls, step, should_summarize, learning_rate,
-      include=None, exclude=None, clipping=None, schedule=None):
+          self, optimizer_cls, step, should_summarize, learning_rate,
+          include=None, exclude=None, clipping=None, schedule=None):
     if schedule:
       learning_rate *= schedule(step)
     self._step = step

--- a/planet/tools/numpy_episodes.py
+++ b/planet/tools/numpy_episodes.py
@@ -31,8 +31,8 @@ from planet.tools import chunk_sequence
 
 
 def numpy_episodes(
-    train_dir, test_dir, shape, loader, preprocess_fn=None, scan_every=10,
-    num_chunks=None, **kwargs):
+        train_dir, test_dir, shape, loader, preprocess_fn=None, scan_every=10,
+        num_chunks=None, **kwargs):
   """Read sequences stored as compressed Numpy files as a TensorFlow dataset.
 
   Args:
@@ -61,6 +61,7 @@ def numpy_episodes(
       functools.partial(loader, test_dir, shape[0], **kwargs), dtypes, shapes)
   chunking = lambda x: tf.data.Dataset.from_tensor_slices(
       chunk_sequence(x, shape[1], True, num_chunks))
+
   def sequence_preprocess_fn(sequence):
     if preprocess_fn:
       with tf.device('/cpu:0'):
@@ -94,7 +95,7 @@ def _read_spec(directory, return_length=False, numpy_types=False, **kwargs):
 
 
 def _read_episodes_scan(
-    directory, batch_size, every, max_episodes=None, **kwargs):
+        directory, batch_size, every, max_episodes=None, **kwargs):
   recent = {}
   cache = {}
   while True:
@@ -138,7 +139,7 @@ def _read_episodes_reload(directory, batch_size, max_episodes=None, **kwargs):
 
 
 def _read_episodes_dummy(
-    directory, batch_size, max_episodes=None, **kwargs):
+        directory, batch_size, max_episodes=None, **kwargs):
   random = np.random.RandomState(seed=0)
   dtypes, shapes, length = _read_spec(directory, True, True, **kwargs)
   while True:
@@ -155,8 +156,8 @@ def _read_episodes_dummy(
 
 
 def _read_episode(
-    filename, resize=None, sub_sample=None, max_length=None,
-    action_noise=None):
+        filename, resize=None, sub_sample=None, max_length=None,
+        action_noise=None):
   with tf.gfile.Open(filename, 'rb') as file_:
     episode = np.load(file_)
   episode = {key: _convert_type(episode[key]) for key in episode.keys()}

--- a/planet/tools/overshooting.py
+++ b/planet/tools/overshooting.py
@@ -26,7 +26,7 @@ from planet.tools import shape
 
 
 def overshooting(
-    cell, target, embedded, prev_action, length, amount, ignore_input=False):
+        cell, target, embedded, prev_action, length, amount, ignore_input=False):
   """Perform open loop rollouts from the posteriors at every step.
 
   First, we apply the encoder to embed raw inputs and apply the model to obtain

--- a/planet/tools/streaming_mean.py
+++ b/planet/tools/streaming_mean.py
@@ -62,10 +62,11 @@ class StreamingMean(object):
     if str(value.shape[1:]) != str(self._sum.shape):
       message = 'Value shape ({}) does not fit tracked tensor ({}).'
       raise ValueError(message.format(value.shape[1:], self._sum.shape))
+
     def assign():
       return tf.group(
-        self._sum.assign_add(tf.reduce_sum(value, 0)),
-        self._count.assign_add(tf.shape(value)[0]))
+          self._sum.assign_add(tf.reduce_sum(value, 0)),
+          self._count.assign_add(tf.shape(value)[0]))
     not_empty = tf.cast(tf.reduce_prod(tf.shape(value)), tf.bool)
     return tf.cond(not_empty, assign, tf.no_op)
 

--- a/planet/tools/unroll.py
+++ b/planet/tools/unroll.py
@@ -28,7 +28,7 @@ def closed_loop(cell, embedded, prev_action, debug=False):
       cell, (embedded, prev_action, use_obs), dtype=tf.float32)
   if debug:
     with tf.control_dependencies([tf.assert_equal(
-        tf.shape(nested.flatten(posterior)[0])[1], tf.shape(embedded)[1])]):
+            tf.shape(nested.flatten(posterior)[0])[1], tf.shape(embedded)[1])]):
       prior = nested.map(tf.identity, prior)
       posterior = nested.map(tf.identity, posterior)
   return prior, posterior
@@ -48,14 +48,14 @@ def open_loop(cell, embedded, prev_action, context=1, debug=False):
       closed_state, open_state)
   if debug:
     with tf.control_dependencies([tf.assert_equal(
-        tf.shape(nested.flatten(state)[0])[1], tf.shape(embedded)[1])]):
+            tf.shape(nested.flatten(state)[0])[1], tf.shape(embedded)[1])]):
       state = nested.map(tf.identity, state)
   return state
 
 
 def planned(
-    cell, objective_fn, embedded, prev_action, planner, context=1, length=20,
-    amount=1000, debug=False):
+        cell, objective_fn, embedded, prev_action, planner, context=1, length=20,
+        amount=1000, debug=False):
   use_obs = tf.ones(tf.shape(embedded[:, :context, :1])[:3], tf.bool)
   (_, closed_state), last_state = tf.nn.dynamic_rnn(
       cell, (embedded[:, :context], prev_action[:, :context], use_obs),
@@ -70,7 +70,7 @@ def planned(
       closed_state, plan_state)
   if debug:
     with tf.control_dependencies([tf.assert_equal(
-        tf.shape(nested.flatten(state)[0])[1], context + length)]):
+            tf.shape(nested.flatten(state)[0])[1], context + length)]):
       state = nested.map(tf.identity, state)
       return_ = tf.identity(return_)
   return state, return_

--- a/planet/training/running.py
+++ b/planet/training/running.py
@@ -47,8 +47,8 @@ class Experiment(object):
   """Experiment class."""
 
   def __init__(
-      self, basedir, process_fn, start_fn=None, resume_fn=None,
-      num_runs=None, worker_name=None, ping_every=30, resume_runs=True):
+          self, basedir, process_fn, start_fn=None, resume_fn=None,
+          num_runs=None, worker_name=None, ping_every=30, resume_runs=True):
     """Coordinate experiments with multiple runs processed by multiple workers.
 
     The experiment can be iterated over to yield runs. Runs can be iterated
@@ -139,8 +139,8 @@ class Experiment(object):
 class Run(object):
 
   def __init__(
-      self, logdir, process_fn, start_fn, resume_fn, worker_name,
-      ping_every=30, ping_stale=60, reuse_if_exists=True):
+          self, logdir, process_fn, start_fn, resume_fn, worker_name,
+          ping_every=30, ping_stale=60, reuse_if_exists=True):
     """Represents a unit of work associated with a log directory.
 
     This class guarantees that in a distributed setting, for every log
@@ -333,8 +333,8 @@ class Run(object):
       self._store_ping(self._logdir)
       while self._running[0]:
         if time.time() >= last_write + self._ping_every:
-            last_write = time.time()
-            self._store_ping(self._logdir)
+          last_write = time.time()
+          self._store_ping(self._logdir)
         # Only wait short times to quickly react to abort.
         time.sleep(0.01)
     except WorkerConflict:

--- a/planet/training/trainer.py
+++ b/planet/training/trainer.py
@@ -91,8 +91,8 @@ class Trainer(object):
     return self._reset
 
   def add_saver(
-      self, include=r'.*', exclude=r'.^', logdir=None, load=True, save=True,
-      checkpoint=None):
+          self, include=r'.*', exclude=r'.^', logdir=None, load=True, save=True,
+          checkpoint=None):
     """Add a saver to save or load variables.
 
     Args:
@@ -117,9 +117,9 @@ class Trainer(object):
       self._checkpoints.append(checkpoint)
 
   def add_phase(
-      self, name, steps, score, summary, batch_size=1,
-      report_every=None, log_every=None, checkpoint_every=None,
-      restore_every=None, feed=None):
+          self, name, steps, score, summary, batch_size=1,
+          report_every=None, log_every=None, checkpoint_every=None,
+          restore_every=None, feed=None):
     """Add a phase to the trainer protocol.
 
     The score tensor can either be a scalar or vector, to support single and
@@ -200,11 +200,11 @@ class Trainer(object):
             phase_step, phase.batch_size, phase.report_every)
         summary, mean_score, global_step = sess.run(phase.op, phase.feed)
         if self._is_every_steps(
-            phase_step, phase.batch_size, phase.checkpoint_every):
+                phase_step, phase.batch_size, phase.checkpoint_every):
           for saver in self._savers:
             self._store_checkpoint(sess, saver, global_step)
         if self._is_every_steps(
-            phase_step, phase.batch_size, phase.report_every):
+                phase_step, phase.batch_size, phase.report_every):
           tf.logging.info('Score {}.'.format(mean_score))
           yield mean_score
         if summary and phase.writer:
@@ -214,7 +214,7 @@ class Trainer(object):
           summary_step = epoch * longest_phase + steps_in
           phase.writer.add_summary(summary, summary_step)
         if self._is_every_steps(
-            phase_step, phase.batch_size, phase.restore_every):
+                phase_step, phase.batch_size, phase.restore_every):
           self._initialize_variables(
               sess, self._loaders, self._logdirs, self._checkpoints)
 
@@ -314,7 +314,7 @@ class Trainer(object):
         tf.global_variables_initializer()))
     assert len(savers) == len(logdirs) == len(checkpoints)
     for i, (saver, logdir, checkpoint) in enumerate(
-        zip(savers, logdirs, checkpoints)):
+            zip(savers, logdirs, checkpoints)):
       logdir = os.path.expanduser(logdir)
       state = tf.train.get_checkpoint_state(logdir)
       if checkpoint:

--- a/planet/training/utility.py
+++ b/planet/training/utility.py
@@ -181,8 +181,8 @@ def train(model_fn, datasets, logdir, config):
 
 
 def compute_losses(
-    loss_scales, cell, heads, step, target, prior, posterior, mask,
-    free_nats=None, debug=False):
+        loss_scales, cell, heads, step, target, prior, posterior, mask,
+        free_nats=None, debug=False):
   features = cell.features_from_state(posterior)
   losses = {}
   for key, scale in loss_scales.items():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
-[pycodestyle]
+[pep8]
 indent-size = 2
+
+[pycodestyle]
 max-line-length = 100
 ignore = E111,E114,E402,E731

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[pycodestyle]
+indent-size = 2
+max-line-length = 100
+ignore = E111,E114,E402,E731


### PR DESCRIPTION
This PR adds `pep8` and `pycodestyle` configurations so tools like `autopep8` and `pycodestyle` can be used to keep the code consistent across different IDEs and developers workspaces.
It also runs autopep8 on every `.py` file so future diffs shouldn't show differences in formatting.