### PR TITLE
Set future_rnn parameter for RSSM instead of SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The code prints `nan` as the score for iterations during which no summaries
 were computed.
 
 The available tasks are listed in `scripts/tasks.py`. The default parameters
-can be found in `scripts/configs.py`. To replicate the experiments in our
+can be found in `scripts/configs.py`. To run the experiments from our
 paper, pass the following parameters to `--params {...}` in addition to the
 list of tasks:
 
@@ -69,6 +69,9 @@ list of tasks:
 | Purely deterministic | `overshooting: 0, mean_only: True, divergence_scale: 0.0, global_divergence_scale: 0.0` |
 | Purely stochastic | `model: ssm` |
 | One agent all tasks | `collect_every: 30000` |
+
+Please note that the agent has seen some improvements so the results may be a
+bit different now.
 
 ## Modifications
 
@@ -103,6 +106,7 @@ The code was tested under Ubuntu 18 and uses these packages:
 - scikit-image
 - scipy
 - ruamel.yaml
+- matplotlib
 
 [dmc-rendering]: https://github.com/deepmind/dm_control#rendering
 

--- a/planet/control/wrappers.py
+++ b/planet/control/wrappers.py
@@ -249,10 +249,8 @@ class NormalizeActions(object):
     self._env = env
     low, high = env.action_space.low, env.action_space.high
     self._enabled = np.logical_and(np.isfinite(low), np.isfinite(high))
-    self._scale = np.where(
-        self._enabled, (high - low) / 2, np.ones_like(low))
-    self._offset = np.where(
-        self._enabled, low + (high - low) / 2, np.zeros_like(low))
+    self._low = np.where(self._enabled, low, -np.ones_like(low))
+    self._high = np.where(self._enabled, high, np.ones_like(low))
 
   def __getattr__(self, name):
     return getattr(self._env, name)
@@ -265,7 +263,7 @@ class NormalizeActions(object):
     return gym.spaces.Box(low, high)
 
   def step(self, action):
-    action = (action - self._offset) / self._scale
+    action = (action + 1) / 2 * (self._high - self._low) + self._low
     return self._env.step(action)
 
 

--- a/planet/networks/basic.py
+++ b/planet/networks/basic.py
@@ -33,6 +33,6 @@ def feed_forward(
     hidden = tf.layers.dense(hidden, 100, tf.nn.relu)
   mean = tf.layers.dense(hidden, int(np.prod(data_shape)), activation)
   mean = tf.reshape(mean, tools.shape(state)[:-1] + data_shape)
-  dist = tools.MSEDistribution(mean)
+  dist = tfd.Normal(mean, 1.0)
   dist = tfd.Independent(dist, len(data_shape))
   return dist

--- a/planet/networks/conv_ha.py
+++ b/planet/networks/conv_ha.py
@@ -50,6 +50,6 @@ def decoder(state, data_shape):
   mean = hidden
   assert mean.shape[1:].as_list() == [64, 64, 3], mean.shape
   mean = tf.reshape(mean, tools.shape(state)[:-1] + data_shape)
-  dist = tools.MSEDistribution(mean)
+  dist = tfd.Normal(mean, 1.0)
   dist = tfd.Independent(dist, len(data_shape))
   return dist

--- a/planet/scripts/configs.py
+++ b/planet/scripts/configs.py
@@ -80,12 +80,11 @@ def _model_components(config, params):
   if model == 'ssm':
     config.cell = functools.partial(
         models.SSM, state_size, size,
-        params.get('future_rnn', False),
         params.mean_only,
         params.get('min_stddev', 1e-1))
   elif model == 'rssm':
     config.cell = functools.partial(
-        models.RSSM, state_size, size, size, params.mean_only,
+        models.RSSM, state_size, size, size, params.get('future_rnn', False), params.mean_only,
         params.get('min_stddev', 1e-1))
   else:
     raise NotImplementedError("Unknown model '{}.".format(params.model))


### PR DESCRIPTION
@danijar You've mentioned in the https://github.com/google-research/planet/issues/21 discussion that the future_rnn should be set for RSSM instead of SSM. I've checked the current source, it seems it is not set this way. There's actually your commit for this yet the configuration file was unchanged. Here's the fix.